### PR TITLE
Remove special handling of .NOTPARALLEL and specify GNU make

### DIFF
--- a/build-api.md
+++ b/build-api.md
@@ -117,7 +117,7 @@ Makefile
 --------
 
 This MUST be a Makefile, as consumable by an implementation of "make"
-such as GNU Make.  It MUST have the following targets:
+compatible with GNU Make.  It MUST have the following targets:
 
 * `all`: Build all of the software.  This variable SHOULD accept a make variable
    called `BUILDAPI_JOBS`.  The `BUILDAPI_JOBS` variable specifies roughly how
@@ -145,10 +145,7 @@ It SHOULD support these individual build targets:
    which specifies an additional file path prefix before the install
    path.
 
-* `.NOTPARALLEL`: This pseudo-target is taken from GNU Make.  Use this
-   to forcibly disable parallel builds if your `Makefile` is not
-   compatible with them.  Obviously, you should try to avoid using
-   this.  One alternative is to progressively, isolate the parts of
-   your build which aren't parallelizable into a separate
-   `Makefile.notparallel` (and use `.NOTPARALLEL`, then and
-   recursively invoke `make -f Makefile.notparallel`).
+Your Makefile must work when run with the `-j <JOBS>` option to make. If
+there are Makefiles within your project that don't work when run like
+this, you can use the GNU make `.NOTPARALLEL:` pseudo-target to
+disable parallel builds for those makefiles.


### PR DESCRIPTION
The handling of the .NOTPARALLEL: pseudo-target was not compatible
with the original behavior in GNU make because it entirely disabled
parallel builds for recursive makes, not just at the toplevel.
This resulted in disabling parallel makes for some CMake projects,
such as webkitgtk.

To make it clear that you can just use .NOTPARALLEL, specify what
was already implied - that the make command used has to be
(sufficiently) compatible with GNU make. To be precise, we'd have
to have a list of extensions that the makefiles can count on, but
in practice, anybody relying on the build-api will just use GNU
make.
